### PR TITLE
Update `tokio` to `1.2.0`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hibitset = { version = "0.6", default-features = false }
 log = "0.4"
 mopa = "0.2"
 thiserror = "1.0"
-tokio = { version = "0.3", features = [ "full", "net", "time", "rt-multi-thread" ] }
+tokio = { version = "1.2", features = [ "full", "net", "time", "rt-multi-thread" ] }
 
 [features]
 default = [ "derive" ]

--- a/src/resource/cell.rs
+++ b/src/resource/cell.rs
@@ -119,7 +119,11 @@ impl<T> Cell<T> {
                 return false;
             }
 
-            if self.flag.compare_and_swap(val, val + 1, Ordering::AcqRel) == val {
+            if self
+                .flag
+                .compare_exchange(val, val + 1, Ordering::AcqRel, Ordering::Acquire)
+                == Ok(val)
+            {
                 return true;
             }
         }
@@ -128,7 +132,9 @@ impl<T> Cell<T> {
     /// Make sure we are allowed to aquire a write lock, and then set the write
     /// lock flag.
     fn check_flag_write(&self) -> bool {
-        self.flag.compare_and_swap(0, usize::MAX, Ordering::AcqRel) == 0
+        self.flag
+            .compare_exchange(0, usize::MAX, Ordering::AcqRel, Ordering::Acquire)
+            == Ok(0)
     }
 }
 


### PR DESCRIPTION
Heya, I bumped tokio to 1.2.0 and replaced [`compare_and_swap` *(deprecated)*](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.compare_and_swap) with [`compare_exchange`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.compare_exchange). I think the code change is correct -- assuming I understood the documentation correctly.
